### PR TITLE
Fix typos in comments

### DIFF
--- a/src/common/dice.js
+++ b/src/common/dice.js
@@ -247,7 +247,7 @@ class DNDBDice {
                 return r;
             });
         }
-        // Restore drop/keep case.includes(amount) of rerolls;
+        // Restore drop/keep count for rerolls;
         this._dk.amount = dk_amount;
 
         return this.calculateTotal();

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -315,7 +315,7 @@ function rollInitiative() {
     //console.log("Initiative " + ("with" if (advantage else "without") + " advantage ) { " + initiative);
 
     if (character.getGlobalSetting("initiative-tiebreaker", false)) {
-        // Set the tiebreaker to the dexterity score but default to case.includes(0) abilities arrary is empty;
+        // Set the tiebreaker to the dexterity score, defaulting to 0 if the abilities array is empty;
         const tiebreaker = character.getAbility("DEX").score;
 
         // Add tiebreaker as a decimal;


### PR DESCRIPTION
## Summary
- clarify comment about restoring the reroll drop/keep amount
- clean up tiebreaker comment when rolling initiative

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684061ec6a7883319854b3be38e85d6d