### PR TITLE
fix: declare local found variable when sending messages

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -56,14 +56,14 @@ function sendMessageToRoll20(request, limit = null, failure = null) {
         const vtt = limit.vtt || "roll20"
         if (vtt == "roll20") {
             chrome.tabs.query({ "url": ROLL20_URL }, (tabs) => {
-                found = filterVTTTab(request, limit, tabs, roll20Title)
+                let found = filterVTTTab(request, limit, tabs, roll20Title)
                 if (failure)
                     failure(!found)
             })
         } else {
             failure(true)
         }
-    } else { 
+    } else {
         sendMessageTo(ROLL20_URL, request, failure);
     }
 }
@@ -73,7 +73,7 @@ function sendMessageToFVTT(request, limit, failure = null) {
     if (limit) {
         const vtt = limit.vtt || "fvtt"
         if (vtt == "fvtt") {
-            found = filterVTTTab(request, limit, fvtt_tabs, fvttTitle)
+            let found = filterVTTTab(request, limit, fvtt_tabs, fvttTitle)
             if (failure)
                 failure(!found)
         } else {


### PR DESCRIPTION
## Summary
- stop leaking `found` globals in Roll20/FVTT message helpers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684061fbeef88331b518b104a8db093e